### PR TITLE
Fix license

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     var respecConfig = {
       specStatus:          "ED",
       shortName:           "tvcontrol-api", // needed for generated URLs
+      license: "w3c-software-doc",
       editors: [{
         w3cid: 62014,
         name: "Steven Morris",


### PR DESCRIPTION
The current charter of the TV Control Working Group asserts that the group will use the W3C Software and Document License:

http://www.w3.org/2016/03/tvcontrol.html#licensing

The TV Control API specification has been incorrectly published under the W3C Document License up until now, though. This update tells ReSpec to use the right license.

(Not sure why the pull request includes 2 "merge" commits, the actual changes seem good. Feel free to use the "squash" merge option to get rid of them)