### PR TITLE
Update SOTD section to note work on the document has been discontinuated

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
         <a href="https://www.w3.org/2011/webtv">Web and TV Interest Group</a>.
         The TV Control Working Group invites interested parties to join and
         contribute to that group. Technical work on this document has been
-        discontinuated in the meantime and the TV Control Working Group has
+        discontinued in the meantime and the TV Control Working Group has
         been closed as a result.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -104,28 +104,27 @@
     </section>
     <!-- - - - - - - - - - - - - - - Status of this document - - - - - - - - - - -->
     <section id="sotd">
+      <p class="warning">
+        Work on this document has been discontinued and it should not be
+        considered as stable, referenced or used as a basis for
+        implementation.
+      </p>
+
       <p>
-        This document is <strong>work in progress</strong> and is subject to
-        change. The API has significantly evolved since publication as a First
-        Public Working Draft on
-        <a href="https://www.w3.org/TR/2016/WD-tvcontrol-api-20160915/"
-        title="First Public Working Draft of the TV Control API">15
-        September 2016</a>. The <code>TVTuner</code> class has been removed
-        in particular, and the API follows a more flexible source-centric
-        design based on the capabilities and constraints model from
-        the <a href="http://www.w3.org/TR/mediacapture-streams/">Media Capture
-        and Streams specification</a> [[MediaCapture-Streams]].
+        The API did not significantly change since publication as Working
+        Draft on <a href=
+        "https://www.w3.org/TR/2017/WD-tvcontrol-api-20170316/" title=
+        "TV Control API Working Draft - 16 March 2017">16 March 2017</a>.
       </p>
       <p>
-        An important issue for the Working Group to address is which functions
-        are appropriate to be accessed from general web applications, and the
-        mechanisms that may be needed to address any security and user privacy
-        concerns.
-      </p>
-      <p>
-        <strong>Changes to this document may be tracked at the specification's
-        <a href="https://github.com/w3c/tvcontrol-api/">GitHub
-        repository</a>.</strong>
+        Further discussions on scope, use cases and requirements are needed for
+        this work to succeed on the Recommendation track. At the time of
+        publication, these discussions are being held in the
+        <a href="https://www.w3.org/2011/webtv">Web and TV Interest Group</a>.
+        The TV Control Working Group invites interested parties to join and
+        contribute to that group. Technical work on this document has been
+        discontinuated in the meantime and the TV Control Working Group has
+        been closed as a result.
       </p>
     </section>
     <!-- - - - - - - - - - - - - - - Introduction  - - - - - - - - - - - - - - - -->


### PR DESCRIPTION
This PR adds a prominent warning to the Status of This Document section so that we may publish the specification as a final Working Group Note.